### PR TITLE
feat(module): export `presets` from `require("ex-colors")` addition to `require("ex-colors.presets")`

### DIFF
--- a/fnl/ex-colors/init.fnl
+++ b/fnl/ex-colors/init.fnl
@@ -1,4 +1,5 @@
 (local config (require :ex-colors.config))
+(local presets (require :ex-colors.presets))
 (local {: define-commands!} (require :ex-colors.commands))
 
 (lua "
@@ -18,4 +19,4 @@
 (fn reset []
   (config.reset))
 
-{: setup : reset}
+{: setup : reset : presets}

--- a/lua/ex-colors/init.lua
+++ b/lua/ex-colors/init.lua
@@ -1,4 +1,5 @@
 local config = require("ex-colors.config")
+local presets = require("ex-colors.presets")
 local _local_1_ = require("ex-colors.commands")
 local define_commands_21 = _local_1_["define-commands!"]
 
@@ -18,4 +19,4 @@ end
 local function reset()
   return config.reset()
 end
-return {setup = setup, reset = reset}
+return {setup = setup, reset = reset, presets = presets}

--- a/test/basic_spec.fnl
+++ b/test/basic_spec.fnl
@@ -4,3 +4,8 @@
 
 (it* "setup can run with no args"
   (assert.has_no_error #(ex-colors.setup)))
+
+(it* "require('ex-colors').presets is equivalent to require('ex-colors.presets')"
+  (assert.is_same (-> (require :ex-colors)
+                      (. :presets))
+                  (require :ex-colors.presets)))


### PR DESCRIPTION
Because any modules of ex-colors are supposed to be loaded only on demand, such performance overheads should never matter so much.