### PR TITLE
fix: create missing subdirectories on `:ExColors`

### DIFF
--- a/fnl/ex-colors/utils/general.fnl
+++ b/fnl/ex-colors/utils/general.fnl
@@ -15,12 +15,12 @@
 
 (fn ensure-dir! [dir-path]
   "Ensure `dir-path` exists in file system. If not existed, ask to create it.
-  @param dir-path string"
+@param dir-path string"
   (assert-is-full-path dir-path (.. "expected absolute path, got " dir-path))
   (when-not (directory? dir-path)
     (case (vim.fn.confirm (.. "Missing " dir-path ", create?") "&No\n&yes" 1
                           :Warning)
-      2 (vim.mkdir dir-path :p)
+      2 (vim.fn.mkdir dir-path :p)
       _ (error (.. "Abort due to missing " dir-path)))))
 
 (fn lines->comment-lines [lines]

--- a/lua/ex-colors/utils/general.lua
+++ b/lua/ex-colors/utils/general.lua
@@ -14,7 +14,7 @@ local function ensure_dir_21(dir_path)
   if not (1 == vim.fn.isdirectory(dir_path)) then
     local _3_ = vim.fn.confirm(("Missing " .. dir_path .. ", create?"), "&No\n&yes", 1, "Warning")
     if (_3_ == 2) then
-      return vim.mkdir(dir_path, "p")
+      return vim.fn.mkdir(dir_path, "p")
     else
       local _ = _3_
       return error(("Abort due to missing " .. dir_path))


### PR DESCRIPTION
correct function call to `vim.fn.mkdir`

Close #21