### PR TITLE
ci(auto-update): update default-colors monthly

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,7 +1,7 @@
-name: Update Default Colors Weekly on Neovim Nightly
+name: Update Default Colors Monthly on Neovim Nightly
 on:
   schedule:
-    - cron: '0 0 * * 5'
+    - cron: '0 0 1-7 * 6'
   workflow_dispatch:
 jobs:
   update-default-colors:


### PR DESCRIPTION
The updates on nvim nightly are too frequent to justify bumping versions, as most changes are just to catch up minor highlight definition updates for some filetypes.

Run the workflow manually if necessary.